### PR TITLE
Hero image & other small edits

### DIFF
--- a/src/components/widgets/CallToAction.astro
+++ b/src/components/widgets/CallToAction.astro
@@ -43,7 +43,7 @@ const {
             callToAction.text &&
             callToAction.href && (
               <div class="mt-6 max-w-xs mx-auto">
-                <a class="btn btn-primary w-full sm:w-auto" href={callToAction.href} target="_blank" rel="noopener">
+                <a class="btn btn-primary w-full sm:w-auto" href={callToAction.href} rel="noopener">
                   {callToAction.icon && <Icon name={callToAction.icon} class="w-5 h-5 mr-1 -ml-1.5" />}
                   {callToAction.text}
                 </a>

--- a/src/components/widgets/Content.astro
+++ b/src/components/widgets/Content.astro
@@ -67,7 +67,7 @@ const {
               {items.map(({ title: title2, description, icon }) => (
                 <div class="flex">
                   <div class="flex-shrink-0">
-                    <div class="flex h-7 w-7 items-center justify-center rounded-full bg-primary text-gray-50">
+                    <div class="flex h-7 w-7 items-center justify-center rounded-full bg-orange-500 text-gray-50">
                       <Icon name={icon ? icon : 'tabler:check'} class="w-5 h-5" />
                     </div>
                   </div>

--- a/src/components/widgets/Hero2.astro
+++ b/src/components/widgets/Hero2.astro
@@ -92,12 +92,14 @@ const {
               ) : (
                 <Picture
                   class="mx-auto rounded-md w-full"
-                  widths={[400, 768, 1024, 2040]}
-                  sizes="(max-width: 767px) 400px, (max-width: 1023px) 768px, (max-width: 2039px) 1024px, 2040px"
+                  widths={[400, 900]}
+                  sizes="(max-width: 900px) 400px, 900px"
                   aspectRatio={600 / 600}
                   loading="eager"
+                  decoding="async"
                   width={600}
                   height={600}
+                  background={undefined}
                   {...image}
                 />
               )}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -63,17 +63,20 @@ const meta = {
       {
         title: 'Code Mentors',
         description:
-        "Experienced Bitcoin and Lightning devs who want to give back and grow new talent"
+        "Experienced Bitcoin and Lightning devs who want to give back and grow new talent",
+        icon: 'tabler:bolt',
         },
       {
         title: 'Seeking Mentoring',
         description:
-        'Plebians who are new to open source, or who are freshly out of bootcamp or code school, and are looking to contribute to their first OSS project'
+        'Plebians who are new to open source, or who are freshly out of bootcamp or code school, and are looking to contribute to their first OSS project',
+        icon: 'tabler:bolt',
       },
       {
         title: 'New Open Source Project Developers',
         description:
-        'Are you Starting a new OSS project in bitcoin or lightining, and are you looking for new Contributors? This is the place to be.'
+        'Are you Starting a new OSS project in bitcoin or lightining, and are you looking for new Contributors? This is the place to be.',
+        icon: 'tabler:bolt',
       },
     ]}
     image={{


### PR DESCRIPTION
Vercel Image deploy Fix
- Picture in Hero2.astro:  limit image rendering dimensions in hero image 
- Vercel production preview deployment: https://bitkarrot-plebnet-website-git-hero-image-bitkarrot.vercel.app/

This PR Also fixes: 
- callToAction.astro : removes _target in a href used at the bottom of index page
- Content.astro: Adds orange LN bolt icons for more consistent look on index.astro page.

