### PR TITLE
Add: Rate Converter to Resources nav and All Resources page

### DIFF
--- a/src/content/post/resources.md
+++ b/src/content/post/resources.md
@@ -34,6 +34,9 @@ At [Plebnet.dev](https://plebnet.dev), our aim is to continually enrich our user
 - **Nostrogen**  
   A fork of the simple nostr vanity address generator. [Access here](https://nostrogen.plebnet.dev/)
 
+- **Rate Converter**  
+  See how many satoshis your fiat is worth. [Check it out](https://rates.plebnet.dev/)
+
 - **Nostr NIP-5 and Lightning Services**
 
   Details coming soon.

--- a/src/data.js
+++ b/src/data.js
@@ -43,6 +43,10 @@ export const headerData = {
           href: 'https://nostrogen.plebnet.dev/',
         },
         {
+          text: 'Rate Converter',
+          href: 'https://rates.plebnet.dev',
+        },
+        {
           text: 'All Resources',
           href: '/resources',
         },


### PR DESCRIPTION
Add the plebnet.dev rate converter (https://rates.plebnet.dev/) to the Resources tab under the nav bar and inside the 'All Resources' page.