### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/src/pages/api/donate.js
+++ b/src/pages/api/donate.js
@@ -30,7 +30,8 @@ export async function POST({request}) {
         
 
     } catch (error) {
-        return new Response(JSON.stringify({ 'error': error }), {
+        console.error("An error occurred:", error); // Log the detailed error on the server
+        return new Response(JSON.stringify({ 'error': "An internal server error occurred" }), {
           status: 500,
           headers: {
             "Content-Type": "application/json"


### PR DESCRIPTION
Potential fix for [https://github.com/plebnet-dev/website/security/code-scanning/1](https://github.com/plebnet-dev/website/security/code-scanning/1)

To fix the issue, the stack trace or sensitive information in the `error` object should not be exposed to the user. Instead, a generic error message should be sent to the user, while the detailed error information (including the stack trace) should be logged on the server for debugging purposes. This ensures that sensitive information is not leaked to the user while still allowing developers to diagnose issues.

Steps to implement the fix:
1. Replace the `JSON.stringify({ 'error': error })` response with a generic error message, such as `"An internal server error occurred"`.
2. Log the detailed error information (including the stack trace) on the server using `console.error` or another logging mechanism.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
